### PR TITLE
fix: modified service container's volume to track the whole application folder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       context: .
       target: dev
     volumes:
-      - ./service/src:/app/src
+      - ./service:/app
       - ./logs:/home/node/.npm/_logs/
     depends_on:
       - db


### PR DESCRIPTION
Due to the volume containing only the app's src folder, the compiled javascript in dist directory was not present on the local machine, so breakpoint mapping and remote debugging was no possible without compiling typescript locally. By extending the volume over the whole application folder, dist directory is created locally and breakpoint mapping is working correctly.